### PR TITLE
Fix empty relay state (#5)

### DIFF
--- a/django_saml/views.py
+++ b/django_saml/views.py
@@ -118,9 +118,10 @@ def saml_acs(request):
             request.session['samlNameIdNameQualifier'] = saml_auth.get_nameid_nq()
             request.session['samlNameIdSPNameQualifier'] = saml_auth.get_nameid_spnq()
             request.session['samlSessionIndex'] = saml_auth.get_session_index()
-            if 'RelayState' in req['post_data'] \
-                    and OneLogin_Saml2_Utils.get_self_url(req) != req['post_data']['RelayState']:
-                url = saml_auth.redirect_to(req['post_data']['RelayState'])
+            relay_state = req['post_data'].get('RelayState')
+            if relay_state \
+                    and OneLogin_Saml2_Utils.get_self_url(req) != relay_state:
+                url = saml_auth.redirect_to(relay_state)
                 return HttpResponseRedirect(url)
             else:
                 return HttpResponseRedirect(settings.SAML_LOGIN_REDIRECT)

--- a/django_saml/views.py
+++ b/django_saml/views.py
@@ -119,7 +119,7 @@ def saml_acs(request):
             request.session['samlNameIdSPNameQualifier'] = saml_auth.get_nameid_spnq()
             request.session['samlSessionIndex'] = saml_auth.get_session_index()
             relay_state = req['post_data'].get('RelayState')
-            if relay_state \
+            if relay_state is not None and len(relay_state) > 0\
                     and OneLogin_Saml2_Utils.get_self_url(req) != relay_state:
                 url = saml_auth.redirect_to(relay_state)
                 return HttpResponseRedirect(url)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -200,6 +200,14 @@ class TestACS(TestCase):
                                     content_type='application/x-www-form-urlencoded')
         self.assertRedirects(response, 'http://127.0.0.1/test', fetch_redirect_response=False)
 
+    def test_redirect_empty_relay_state(self):
+        """Test view redirects properly and ignores empty RelayState."""
+        xml = _file_contents(os.path.join(data_directory, 'login_response.xml'))
+        message = 'SAMLResponse={}&RelayState={}'.format(quote(base64.b64encode(xml.encode())), '')
+        response = self.client.post(reverse('django_saml:acs'), data=message, HTTP_HOST='127.0.0.1',
+                                    content_type='application/x-www-form-urlencoded')
+        self.assertRedirects(response, '/', fetch_redirect_response=False)
+
     def test_acs_get(self):
         """Test invalid methods."""
         response = self.client.get(reverse('django_saml:acs'))
@@ -320,7 +328,7 @@ class TestBackend(TestCase):
         request = self.factory.post('/saml/acs')
         session_data = {'email': ['test@example.com'], 'givenName': ['Bob'], 'username': ['abc1234']}
         user = self.backend.authenticate(request=request, session_data=session_data)
-        # The first name field should still be set even though it is update ignored 
+        # The first name field should still be set even though it is update ignored
         self.assertEqual(user.first_name, 'Bob')
         self.assertEqual(user.email, 'test@example.com')
 


### PR DESCRIPTION
Okta sends an empty relay state, if none is provided. This generates an
error, as the key is present in the post data, and by design different
from the current URL. So we try to redirect to the empty URL.

Also tuck the relaystate into a variable for readability and provide a
test for this case.